### PR TITLE
Added Competitions page ✅

### DIFF
--- a/app/competitions/components/CompetitionCard.jsx
+++ b/app/competitions/components/CompetitionCard.jsx
@@ -1,0 +1,54 @@
+import { Card, CardContent, CardMedia } from '@mui/material';
+import CompetitionCardDateRow from './competition card/CompetitionCardDateRow';
+import CompetitionCardFlag from './competition card/CompetitionCardFlag';
+import CompetitionCardFooter from './competition card/CompetitionCardFooter';
+import CompetitionCardHeader from './competition card/CompetitionCardHeader';
+
+export default function CompetitionCard({ competition }) {
+
+
+  return (
+    <Card sx={{
+      height: '100%',
+      display: 'flex',
+      flexDirection: 'column',
+      transition: 'transform 0.2s',
+      '&:hover': {
+        transform: 'translateY(-5px)',
+        boxShadow: 3
+      }
+    }}>
+      {/* Flag Container */}
+      {competition.area.flag && (
+        <CompetitionCardFlag competition={competition} />
+      )}
+
+      <CardMedia
+        component="img"
+        height="140"
+        image={competition.emblem}
+        alt={competition.name}
+        sx={{
+          objectFit: 'contain',
+          p: 2,
+          backgroundColor: 'rgba(255, 255, 255, 0.05)'
+        }}
+      />
+
+      <CardContent sx={{
+        flexGrow: 1,
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'space-between',
+        pt: 1
+      }}>
+        <CompetitionCardHeader competition={competition} />
+
+        <CompetitionCardDateRow competition={competition} />
+
+        <CompetitionCardFooter competition={competition} />
+
+      </CardContent>
+    </Card>
+  )
+}

--- a/app/competitions/components/CompetitionsGrid.jsx
+++ b/app/competitions/components/CompetitionsGrid.jsx
@@ -1,0 +1,16 @@
+import { Container, Grid } from "@mui/material";
+import CompetitionCard from "./CompetitionCard";
+
+export default function CompetitionsGrid({ data }) {
+  return (
+    <Container sx={{ paddingBottom: 4 }}>
+    <Grid container spacing={3}>
+      {data.competitions.map((competition) => (
+        <Grid item xs={12} sm={6} md={4} lg={3} key={competition.id}>
+          <CompetitionCard competition={competition} />
+        </Grid>
+      ))}
+    </Grid>
+  </Container>
+  )
+}

--- a/app/competitions/components/competition card/CompetitionCardDateRow.jsx
+++ b/app/competitions/components/competition card/CompetitionCardDateRow.jsx
@@ -1,0 +1,63 @@
+import { CalendarMonth, EventAvailable, EventBusy } from "@mui/icons-material";
+import { Box, Typography } from "@mui/material";
+
+export default function CompetitionCardDateRow({ competition}) {
+    const startDate = new Date(competition.currentSeason.startDate).toLocaleDateString();
+    const endDate = new Date(competition.currentSeason.endDate).toLocaleDateString();
+    const matchday = competition.currentSeason.currentMatchday;
+  return (
+    <Box sx={{
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        mb: 1,
+        '& > div': {
+          flex: 1,
+          textAlign: 'center',
+        }
+      }}>
+        
+        {/* Start Date */}
+        <Box> 
+          <EventAvailable fontSize="large" sx={{ color: 'text.secondary'}} />
+          <Typography variant="caption" display="block" fontWeight={500}>
+            Start
+          </Typography>
+          <Typography variant="body2" fontSize="0.75rem">
+            {startDate}
+          </Typography>
+        </Box>
+
+        <Typography variant="body2" sx={{ color: 'divider' }}>|</Typography>
+
+        {/* End Date */}    
+        <Box sx={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+        }}>
+          <EventBusy fontSize="large" sx={{ color: 'text.secondary'}} />
+          <Typography variant="caption" display="block" fontWeight={500}>
+            End
+          </Typography>
+          <Typography variant="body2" fontSize="0.75rem">
+            {endDate}
+          </Typography>
+        </Box>
+
+        <Typography variant="body2" sx={{ color: 'divider' }}>|</Typography>
+
+        {/* Matchday */}
+        <Box>
+          <CalendarMonth fontSize="large" sx={{ color: 'text.secondary'}} />
+          <Typography variant="caption" display="block" fontWeight={500}>
+            Matchday
+          </Typography>
+          <Typography variant="body2" fontSize="0.75rem">
+            {matchday}
+          </Typography>
+        </Box>
+
+      </Box>
+  )
+}

--- a/app/competitions/components/competition card/CompetitionCardFlag.jsx
+++ b/app/competitions/components/competition card/CompetitionCardFlag.jsx
@@ -1,0 +1,27 @@
+import { Box } from "@mui/material";
+
+export default function CompetitionCardFlag({ competition }) {
+  return (
+    <Box sx={{
+        position: 'absolute',
+        top: 16,
+        right: 16,
+        zIndex: 1,
+        bgcolor: 'background.paper',
+        borderRadius: '4px',
+        p: 0.5,
+        boxShadow: 1
+      }}>
+        <img
+          src={competition.area.flag}
+          alt={competition.area.name}
+          style={{
+            height: '24px',
+            width: '32px',
+            objectFit: 'cover',
+            display: 'block'
+          }}
+        />
+      </Box>
+  )
+}

--- a/app/competitions/components/competition card/CompetitionCardFooter.jsx
+++ b/app/competitions/components/competition card/CompetitionCardFooter.jsx
@@ -1,0 +1,50 @@
+import { Military } from '@mui/icons-material';
+import { Box, Chip, Typography } from '@mui/material';
+import { formatDistanceToNow } from 'date-fns';
+import { getPlanColor } from '../helpers';
+
+export default function CompetitionCardFooter({ competition }) {
+  return (
+    <Box sx={{
+        pt: 1,
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+      }}>
+        <Box sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
+          {competition.tier && (
+            <Chip
+              icon={<Military fontSize="small" />}
+              label={`Tier ${competition.tier}`}
+              size="small"
+              sx={{
+                fontWeight: 600,
+                bgcolor: 'action.selected',
+                '& .MuiChip-icon': {
+                  fontSize: '16px',
+                  ml: 0.5
+                }
+              }}
+            />
+          )}
+          <Chip
+            label={competition.plan.replace('_', ' ')}
+            size="small"
+            color={getPlanColor(competition.plan)}
+            sx={{
+              fontWeight: 600,
+              textTransform: 'uppercase'
+            }}
+          />
+        </Box>
+
+        <Typography variant="caption" sx={{
+          color: 'text.secondary',
+          fontSize: '0.7rem',
+          whiteSpace: 'nowrap'
+        }}>
+          Updated {formatDistanceToNow(new Date(competition.lastUpdated))} ago
+        </Typography>
+      </Box>
+  )
+}

--- a/app/competitions/components/competition card/CompetitionCardHeader.jsx
+++ b/app/competitions/components/competition card/CompetitionCardHeader.jsx
@@ -1,0 +1,55 @@
+import { EmojiEvents } from "@mui/icons-material";
+import { Box, Typography } from "@mui/material";
+
+export default function CompetitionCardHeader({ competition }) {
+  return (
+    <Box sx={{ mb: 2, position: 'relative' }}>
+    {/* Competition Name */}
+    <Typography variant="h6" sx={{
+      fontWeight: 700,
+      lineHeight: 1.2,
+      pr: competition.currentSeason.winner ? 12 : 4,
+      '& span': {
+        display: 'block',
+        color: 'text.secondary',
+        fontSize: '0.75rem',
+        textTransform: 'uppercase',
+        mt: 0.5
+      }
+    }}>
+      <div style={{
+        display: '-webkit-box',
+        WebkitLineClamp: 2,
+        WebkitBoxOrient: 'vertical',
+        overflow: 'hidden'
+      }}>
+        {competition.name}
+      </div>
+      <span>{competition.type}</span>
+    </Typography>
+
+    {/* Champion Badge */}
+    {competition.currentSeason.winner && (
+      <Box sx={{
+        position: 'absolute',
+        right: 0,
+        top: 10,
+        display: 'flex',
+        alignItems: 'center',
+        gap: 0.5,
+        bgcolor: 'background.paper',
+        p: 0.5,
+        borderRadius: 1,
+        boxShadow: 1,
+        border: '1px solid',
+        borderColor: 'divider'
+      }}>
+        <EmojiEvents fontSize="small" sx={{ color: 'goldenrod' }} />
+        <Typography variant="body2" fontSize="0.75rem" fontWeight={600}>
+          {competition.currentSeason.winner.name}
+        </Typography>
+      </Box>
+    )}
+  </Box>
+  )
+}

--- a/app/competitions/components/helpers.js
+++ b/app/competitions/components/helpers.js
@@ -1,0 +1,7 @@
+export const getPlanColor = (plan) => {
+  switch (plan) {
+    case 'TIER_ONE': return 'success';
+    case 'TIER_FOUR': return 'warning';
+    default: return 'primary';
+  }
+};

--- a/app/competitions/data.json
+++ b/app/competitions/data.json
@@ -1,0 +1,331 @@
+{
+    "count": 13,
+    "filters": {
+        "client": "Mohamed"
+    },
+    "competitions": [
+        {
+            "id": 2013,
+            "area": {
+                "id": 2032,
+                "name": "Brazil",
+                "code": "BRA",
+                "flag": "https://crests.football-data.org/764.svg"
+            },
+            "name": "Campeonato Brasileiro Série A",
+            "code": "BSA",
+            "type": "LEAGUE",
+            "emblem": "https://crests.football-data.org/bsa.png",
+            "plan": "TIER_ONE",
+            "currentSeason": {
+                "id": 2371,
+                "startDate": "2025-03-29",
+                "endDate": "2025-12-21",
+                "currentMatchday": 1,
+                "winner": null
+            },
+            "numberOfAvailableSeasons": 9,
+            "lastUpdated": "2024-09-13T16:55:53Z"
+        },
+        {
+            "id": 2016,
+            "area": {
+                "id": 2072,
+                "name": "England",
+                "code": "ENG",
+                "flag": "https://crests.football-data.org/770.svg"
+            },
+            "name": "Championship",
+            "code": "ELC",
+            "type": "LEAGUE",
+            "emblem": "https://crests.football-data.org/ELC.png",
+            "plan": "TIER_ONE",
+            "currentSeason": {
+                "id": 2301,
+                "startDate": "2024-08-09",
+                "endDate": "2025-05-03",
+                "currentMatchday": 37,
+                "winner": null
+            },
+            "numberOfAvailableSeasons": 8,
+            "lastUpdated": "2024-09-13T16:51:18Z"
+        },
+        {
+            "id": 2021,
+            "area": {
+                "id": 2072,
+                "name": "England",
+                "code": "ENG",
+                "flag": "https://crests.football-data.org/770.svg"
+            },
+            "name": "Premier League",
+            "code": "PL",
+            "type": "LEAGUE",
+            "emblem": "https://crests.football-data.org/PL.png",
+            "plan": "TIER_ONE",
+            "currentSeason": {
+                "id": 2287,
+                "startDate": "2024-08-16",
+                "endDate": "2025-05-25",
+                "currentMatchday": 28,
+                "winner": null
+            },
+            "numberOfAvailableSeasons": 126,
+            "lastUpdated": "2024-09-13T16:51:24Z"
+        },
+        {
+            "id": 2001,
+            "area": {
+                "id": 2077,
+                "name": "Europe",
+                "code": "EUR",
+                "flag": "https://crests.football-data.org/EUR.svg"
+            },
+            "name": "UEFA Champions League",
+            "code": "CL",
+            "type": "CUP",
+            "emblem": "https://crests.football-data.org/CL.png",
+            "plan": "TIER_ONE",
+            "currentSeason": {
+                "id": 2350,
+                "startDate": "2024-09-17",
+                "endDate": "2025-05-31",
+                "currentMatchday": 2,
+                "winner": null
+            },
+            "numberOfAvailableSeasons": 45,
+            "lastUpdated": "2024-09-13T16:53:48Z"
+        },
+        {
+            "id": 2018,
+            "area": {
+                "id": 2077,
+                "name": "Europe",
+                "code": "EUR",
+                "flag": "https://crests.football-data.org/EUR.svg"
+            },
+            "name": "European Championship",
+            "code": "EC",
+            "type": "CUP",
+            "emblem": "https://crests.football-data.org/ec.png",
+            "plan": "TIER_ONE",
+            "currentSeason": {
+                "id": 1537,
+                "startDate": "2024-06-14",
+                "endDate": "2024-07-14",
+                "currentMatchday": 7,
+                "winner": {
+                    "id": 760,
+                    "name": "Spain",
+                    "shortName": "Spain",
+                    "tla": "ESP",
+                    "crest": "https://crests.football-data.org/760.svg",
+                    "address": "Ramón y Cajal, s/n Las Rozas 28230",
+                    "website": "http://www.rfef.es",
+                    "founded": 1909,
+                    "clubColors": "Red / Blue / Yellow",
+                    "venue": "Estadio Alfredo Di Stéfano",
+                    "lastUpdated": "2021-05-26T09:46:48Z"
+                }
+            },
+            "numberOfAvailableSeasons": 17,
+            "lastUpdated": "2024-09-13T17:04:30Z"
+        },
+        {
+            "id": 2015,
+            "area": {
+                "id": 2081,
+                "name": "France",
+                "code": "FRA",
+                "flag": "https://crests.football-data.org/773.svg"
+            },
+            "name": "Ligue 1",
+            "code": "FL1",
+            "type": "LEAGUE",
+            "emblem": "https://crests.football-data.org/FL1.png",
+            "plan": "TIER_ONE",
+            "currentSeason": {
+                "id": 2290,
+                "startDate": "2024-08-18",
+                "endDate": "2025-05-18",
+                "currentMatchday": 25,
+                "winner": null
+            },
+            "numberOfAvailableSeasons": 81,
+            "lastUpdated": "2024-09-13T16:49:18Z"
+        },
+        {
+            "id": 2002,
+            "area": {
+                "id": 2088,
+                "name": "Germany",
+                "code": "DEU",
+                "flag": "https://crests.football-data.org/759.svg"
+            },
+            "name": "Bundesliga",
+            "code": "BL1",
+            "type": "LEAGUE",
+            "emblem": "https://crests.football-data.org/BL1.png",
+            "plan": "TIER_ONE",
+            "currentSeason": {
+                "id": 2308,
+                "startDate": "2024-08-23",
+                "endDate": "2025-05-17",
+                "currentMatchday": 25,
+                "winner": null
+            },
+            "numberOfAvailableSeasons": 62,
+            "lastUpdated": "2024-09-13T16:48:00Z"
+        },
+        {
+            "id": 2019,
+            "area": {
+                "id": 2114,
+                "name": "Italy",
+                "code": "ITA",
+                "flag": "https://crests.football-data.org/784.svg"
+            },
+            "name": "Serie A",
+            "code": "SA",
+            "type": "LEAGUE",
+            "emblem": "https://crests.football-data.org/SA.png",
+            "plan": "TIER_ONE",
+            "currentSeason": {
+                "id": 2310,
+                "startDate": "2024-08-18",
+                "endDate": "2025-05-25",
+                "currentMatchday": 28,
+                "winner": null
+            },
+            "numberOfAvailableSeasons": 93,
+            "lastUpdated": "2024-09-13T16:50:07Z"
+        },
+        {
+            "id": 2003,
+            "area": {
+                "id": 2163,
+                "name": "Netherlands",
+                "code": "NLD",
+                "flag": "https://crests.football-data.org/8601.svg"
+            },
+            "name": "Eredivisie",
+            "code": "DED",
+            "type": "LEAGUE",
+            "emblem": "https://crests.football-data.org/ED.png",
+            "plan": "TIER_ONE",
+            "currentSeason": {
+                "id": 2293,
+                "startDate": "2024-08-09",
+                "endDate": "2025-05-18",
+                "currentMatchday": 25,
+                "winner": null
+            },
+            "numberOfAvailableSeasons": 69,
+            "lastUpdated": "2024-09-13T16:34:42Z"
+        },
+        {
+            "id": 2017,
+            "area": {
+                "id": 2187,
+                "name": "Portugal",
+                "code": "POR",
+                "flag": "https://crests.football-data.org/765.svg"
+            },
+            "name": "Primeira Liga",
+            "code": "PPL",
+            "type": "LEAGUE",
+            "emblem": "https://crests.football-data.org/PPL.png",
+            "plan": "TIER_ONE",
+            "currentSeason": {
+                "id": 2312,
+                "startDate": "2024-08-11",
+                "endDate": "2025-05-17",
+                "currentMatchday": 25,
+                "winner": null
+            },
+            "numberOfAvailableSeasons": 76,
+            "lastUpdated": "2024-09-13T16:54:08Z"
+        },
+        {
+            "id": 2152,
+            "area": {
+                "id": 2220,
+                "name": "South America",
+                "code": "SAM",
+                "flag": "https://crests.football-data.org/CLI.svg"
+            },
+            "name": "Copa Libertadores",
+            "code": "CLI",
+            "type": "CUP",
+            "emblem": "https://crests.football-data.org/CLI.svg",
+            "plan": "TIER_FOUR",
+            "currentSeason": {
+                "id": 2366,
+                "startDate": "2025-02-05",
+                "endDate": "2025-11-28",
+                "currentMatchday": 2,
+                "winner": null
+            },
+            "numberOfAvailableSeasons": 5,
+            "lastUpdated": "2025-02-13T21:08:12Z"
+        },
+        {
+            "id": 2014,
+            "area": {
+                "id": 2224,
+                "name": "Spain",
+                "code": "ESP",
+                "flag": "https://crests.football-data.org/760.svg"
+            },
+            "name": "Primera Division",
+            "code": "PD",
+            "type": "LEAGUE",
+            "emblem": "https://crests.football-data.org/laliga.png",
+            "plan": "TIER_ONE",
+            "currentSeason": {
+                "id": 2292,
+                "startDate": "2024-08-18",
+                "endDate": "2025-05-25",
+                "currentMatchday": 27,
+                "winner": null
+            },
+            "numberOfAvailableSeasons": 94,
+            "lastUpdated": "2024-09-13T16:52:33Z"
+        },
+        {
+            "id": 2000,
+            "area": {
+                "id": 2267,
+                "name": "World",
+                "code": "INT",
+                "flag": null
+            },
+            "name": "FIFA World Cup",
+            "code": "WC",
+            "type": "CUP",
+            "emblem": "https://crests.football-data.org/qatar.png",
+            "plan": "TIER_ONE",
+            "currentSeason": {
+                "id": 1382,
+                "startDate": "2022-11-20",
+                "endDate": "2022-12-18",
+                "currentMatchday": 8,
+                "winner": {
+                    "id": 762,
+                    "name": "Argentina",
+                    "shortName": "Argentina",
+                    "tla": "ARG",
+                    "crest": "https://crests.football-data.org/762.png",
+                    "address": "Viamonte 1366/76 Buenos Aires, Buenos Aires 1053",
+                    "website": "http://www.afa.org.ar",
+                    "founded": 1893,
+                    "clubColors": "Sky Blue / White / Black",
+                    "venue": null,
+                    "lastUpdated": "2022-05-17T21:09:25Z"
+                }
+            },
+            "numberOfAvailableSeasons": 22,
+            "lastUpdated": "2024-09-13T17:04:20Z"
+        }
+    ]
+}

--- a/app/competitions/page.jsx
+++ b/app/competitions/page.jsx
@@ -1,8 +1,14 @@
+import CustomAppBar from '../../components/CustomAppBar';
+import CompetitionsGrid from './components/CompetitionsGrid';
+import data from './data.json';
 
-export default function page() {
+const CompetitionsPage = () => {
   return (
-    <div>
-        Competition List
-    </div>
-  )
-}
+    <>
+      <CustomAppBar title="Football Competitions"/>
+      <CompetitionsGrid data={data}></CompetitionsGrid>
+    </>
+  );
+};
+
+export default CompetitionsPage;

--- a/components/CustomAppBar.jsx
+++ b/components/CustomAppBar.jsx
@@ -1,0 +1,72 @@
+'use client';
+import { SportsSoccer } from '@mui/icons-material';
+import { AppBar, Box, keyframes, Toolbar, Typography } from '@mui/material';
+
+const fadeIn = keyframes`
+  from { opacity: 0; transform: translateY(-20px); }
+  to { opacity: 1; transform: translateY(0); }
+`;
+
+export default function CustomAppBar({ title, icon: Icon = SportsSoccer }) {
+  return (
+    <AppBar position="static" sx={{
+      mb: 4,
+      backgroundColor: 'rgba(195, 204, 90, 0.40)', 
+      backgroundImage: 'linear-gradient(to right, hsla(65, 52.80%, 57.60%, 0.10) 0%, rgba(195, 204, 90, 0.05) 50%, rgba(195, 204, 90, 0.1) 100%)',
+      boxShadow: '0 4px 20px rgba(0, 0, 0, 0.1)',
+      borderBottom: '1px solid rgba(195, 204, 90, 0.15)',
+      animation: `${fadeIn} 0.6s ease-out`,
+      height: '100px',
+      display: 'flex',
+      justifyContent: 'center'
+    }}>
+      <Toolbar sx={{
+        justifyContent: 'space-between',
+        px: 3,
+        '&:before': {
+          background: 'linear-gradient(120deg, rgba(195, 204, 90, 0.05) 0%, transparent 50%, rgba(195, 204, 90, 0.05) 100%)',
+        }
+      }}>
+        {/* Left Section */}
+        <Box sx={{ display: 'flex' }}>
+          <Icon sx={{
+            fontSize: '2rem',
+            color: '#c3cc5a',
+          }} />
+        </Box>
+
+        {/* Center Section */}
+        <Typography variant="h5" component="div" sx={{
+          fontStyle: 'italic',
+          fontWeight: 300,
+          letterSpacing: 4,
+          color: '#c3cc5a',
+          textShadow: '0 2px 4px rgba(0,0,0,0.2)',
+          position: 'relative',
+          '&:after': {
+            content: '""',
+            position: 'absolute',
+            bottom: -4,
+            left: '50%',
+            transform: 'translateX(-50%)',
+            width: '60%',
+            height: '1px',
+            background: 'rgba(195, 204, 90, 0.3)',
+            borderRadius: '2px'
+          }
+        }}>
+          {title}
+        </Typography>
+
+        {/* Right Section */}
+        <Box sx={{ display: 'flex' }}>
+          <Icon sx={{
+            fontSize: '2rem',
+            color: '#c3cc5a',
+          }} />
+        </Box>
+        
+      </Toolbar>
+    </AppBar>
+  )
+}


### PR DESCRIPTION
#  **Competition Card Components**
   ```jsx
   <CompetitionCard competition={competition} />
   ```
   - **Card Anatomy**:
     - `CompetitionCardFlag`: Country flag display
     - `CardMedia`: Competition emblem image with contained sizing
     - `CompetitionCardHeader`: Name and competition type (League/Cup) and winner
     - `CompetitionCardDateRow`: Start/End dates + Matchday
     - `CompetitionCardFooter`: Tier badge + Last updated time


# **Screenshot Comparison**
![image](https://github.com/user-attachments/assets/f95245aa-1cf2-4327-a3bd-38758a235b22)
